### PR TITLE
Make buffer initialization explicit

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -23,8 +23,9 @@ your `lscpu`, `rustc --version`, and the exact `cargo bench` command.
 - All **realistic** benchmarks write one byte per 4 KiB page so a fresh
   `Vec` pays the page-fault cost. This matches real I/O, networking, and
   serialization workloads.
-- All **hot_path** benchmarks are pure `alloc` / `drop` with no page
-  writes. They are intentionally optimistic and show lower bounds.
+- All **hot_path** benchmarks are pure allocation / drop with no page writes.
+  `alloc()` measures the safe zero-initialized path; `alloc_uninit()` measures
+  the explicit full-overwrite fast path.
 - Each Criterion group runs at least 30 samples (50+ for write workloads)
   with default warm-up.
 - Comparison crates are pulled in only with `--features bench` so the
@@ -81,7 +82,8 @@ N typed pools, and stays within a few percent of their raw speed.
 
 ## Single-thread hot path
 
-Pure `alloc` + `drop`, no page writes. 64 KiB rows.
+Pure allocation + drop, no page writes. 64 KiB rows. Use `alloc_uninit()` for
+the non-zeroing fast path when callers initialize every byte before reading.
 
 | Crate | Time |
 |---|---:|

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,14 +20,14 @@ readme = "README.md"
 # Strategy: Deny critical issues, warn on quality/style issues
 
 [lints.rust]
-# Warn on unsafe code usage (we allow it but want visibility)
-unsafe_code = "warn"
+# Unsafe is allowed in this crate when documented and contained.
+unsafe_code = "allow"
 # Enforce documentation for public API
 missing_docs = "warn"
 # Warn on missing debug implementations
 missing_debug_implementations = "warn"
 # Catch unused items
-unused = "warn"
+unused = { level = "warn", priority = -2 }
 
 [lints.clippy]
 # =============================================================================
@@ -38,6 +38,7 @@ correctness = { level = "deny", priority = -1 }
 suspicious = { level = "deny", priority = -1 }
 perf = { level = "deny", priority = -1 }
 undocumented_unsafe_blocks = { level = "deny", priority = -1 }
+missing_safety_doc = { level = "deny", priority = -1 }
 
 # =============================================================================
 # WARN: Code quality, style, and best practices

--- a/README.md
+++ b/README.md
@@ -12,12 +12,16 @@ Every `Vec::with_capacity(n)` asks the kernel for memory, and every `drop` gives
 
 ZeroPool keeps a pool of reusable byte buffers organized by size class. Buffers are handed out through thread-local caches backed by a lock-free shared queue, so the hot path is a TLS pop with no locks or atomics. When you're done, the buffer goes back to the pool instead of the OS.
 
+The safe default, `alloc(size)`, returns zero-initialized readable bytes. For full-overwrite workloads, `alloc_uninit(size)` skips zeroing and uses a `BufUninit` type that cannot be read from safe code until initialized.
+
 ## Features
 
 - **Size-class bucketing**: 8 power-of-two classes (4 KB to 64 MB), O(1) class selection
 - **Lock-free shared pool**: [`crossbeam::ArrayQueue`](https://docs.rs/crossbeam-queue) per class, no mutexes
 - **Thread-local caching**: per-class LIFO caches with magazine-style batch transfer
 - **Pool isolation**: unique pool IDs prevent TLS cache cross-contamination
+- **Safe by default**: `alloc()` zeroes visible bytes so recycled contents are not exposed
+- **Explicit fast path**: `alloc_uninit()` avoids zeroing for callers that fully overwrite
 - **Pluggable allocator**: custom buffer creation via the [`Allocator`](https://docs.rs/zeropool/latest/zeropool/trait.Allocator.html) trait
 - **Pinned memory**: optional `mlock` to keep buffers out of swap
 - **Opt-in stats**: atomic counters for hit rates, allocations, and discards (disabled by default)
@@ -37,9 +41,20 @@ use zeropool::ZeroPool;
 
 let pool = ZeroPool::new();
 
-let mut buf = pool.alloc(1024 * 1024); // 1 MB, RAII guard
+let mut buf = pool.alloc(1024 * 1024); // 1 MB, zero-initialized RAII guard
 buf[0] = 42;                            // Deref<Target = [u8]>
 // returned to pool on drop
+```
+
+For the fastest path, initialize through `BufUninit` and convert after all bytes are written:
+
+```rust
+use zeropool::ZeroPool;
+
+let pool = ZeroPool::new();
+let buf = pool.alloc_uninit(5).write_from_slice(b"hello");
+
+assert_eq!(&*buf, b"hello");
 ```
 
 ### Sharing across threads
@@ -90,10 +105,7 @@ use zeropool::{Allocator, ZeroPool};
 struct HugePageAllocator;
 impl Allocator for HugePageAllocator {
     fn allocate(&self, capacity: usize) -> Vec<u8> {
-        let mut buf = Vec::with_capacity(capacity);
-        buf.resize(capacity, 0); // pre-fault pages
-        buf.clear();
-        buf
+        vec![0; capacity]
     }
 }
 
@@ -119,7 +131,7 @@ println!("{s}");
 
 ## Performance
 
-Every "realistic" benchmark writes to every page of the buffer, paying the page-fault cost that dominates real workloads (networking, serialization, file I/O). Pure alloc/drop microbenchmarks hide this cost.
+Every "realistic" benchmark writes to every page of the buffer, paying the page-fault cost that dominates real workloads (networking, serialization, file I/O). Pure alloc/drop microbenchmarks hide this cost. Use `alloc_uninit()` for the historical non-zeroing fast path when your workload fully overwrites the buffer.
 
 ### Realistic 64 KiB write, 200 ops/thread
 

--- a/benches/pool.rs
+++ b/benches/pool.rs
@@ -54,6 +54,15 @@ fn hot_path(c: &mut Criterion) {
             });
         });
 
+        group.bench_with_input(BenchmarkId::new("zeropool_uninit", size), &size, |b, &size| {
+            let pool = common::competitors::zeropool_default();
+            b.iter(|| {
+                let buf = pool.alloc_uninit(size);
+                black_box(&buf);
+                drop(buf);
+            });
+        });
+
         group.bench_with_input(BenchmarkId::new("zeropool_stats", size), &size, |b, &size| {
             let pool = common::competitors::zeropool_with_stats();
             b.iter(|| {

--- a/src/allocator.rs
+++ b/src/allocator.rs
@@ -1,15 +1,16 @@
 //! Pluggable buffer allocation backend.
 //!
 //! [`ZeroPool`](crate::ZeroPool) delegates raw buffer creation to an [`Allocator`].
-//! The default [`HeapAllocator`] uses `Vec::with_capacity` (standard heap).
+//! The default [`HeapAllocator`] returns zero-initialized heap buffers.
 //! Implement the trait for custom strategies (page-aligned, huge pages, etc.).
 
 /// Controls how the pool creates raw byte buffers.
 ///
 /// # Contract
 ///
-/// - `allocate(capacity)` must return a `Vec<u8>` with `capacity() >= capacity`.
-/// - The returned `Vec` must have `len() == 0`.
+/// - `allocate(capacity)` must return a `Vec<u8>` with `len() >= capacity`.
+/// - The first `capacity` bytes must be initialized to zero.
+/// - The returned `Vec` must have `capacity() >= len()`.
 /// - The `Vec` must be deallocatable by the standard global allocator.
 ///
 /// # Example
@@ -21,30 +22,27 @@
 ///
 /// impl Allocator for PrefaultAllocator {
 ///     fn allocate(&self, capacity: usize) -> Vec<u8> {
-///         let mut buf = Vec::with_capacity(capacity);
-///         buf.resize(capacity, 0); // pre-fault pages
-///         buf.clear();
-///         buf
+///         vec![0; capacity]
 ///     }
 /// }
 ///
 /// let pool = ZeroPool::new().allocator(PrefaultAllocator);
 /// ```
 pub trait Allocator: Send + Sync + 'static {
-    /// Allocate a buffer with at least `capacity` bytes.
+    /// Allocate a zero-initialized buffer with at least `capacity` bytes.
     fn allocate(&self, capacity: usize) -> Vec<u8>;
 }
 
-/// Standard heap allocation via `Vec::with_capacity`.
+/// Standard heap allocation via `vec![0; capacity]`.
 ///
-/// This is the default — zero-sized, no overhead.
+/// This is the default safe allocator used by [`ZeroPool`](crate::ZeroPool).
 #[derive(Debug, Clone, Copy, Default)]
 pub struct HeapAllocator;
 
 impl Allocator for HeapAllocator {
     #[inline]
     fn allocate(&self, capacity: usize) -> Vec<u8> {
-        Vec::with_capacity(capacity)
+        vec![0; capacity]
     }
 }
 

--- a/src/buf.rs
+++ b/src/buf.rs
@@ -2,7 +2,9 @@
 
 use std::fmt;
 use std::io;
+use std::mem::MaybeUninit;
 use std::ops::{Deref, DerefMut};
+use std::ptr;
 
 use crate::ZeroPool;
 
@@ -28,6 +30,18 @@ use crate::ZeroPool;
 /// }
 /// ```
 pub struct Buf<'a> {
+    buffer: Option<Vec<u8>>,
+    pool: &'a ZeroPool,
+    class_idx: u8,
+}
+
+/// An allocated byte buffer whose contents are not guaranteed to be initialized.
+///
+/// `BufUninit` is the high-performance counterpart to [`Buf`]. It never
+/// dereferences to `[u8]`, so safe code cannot read recycled or uninitialized
+/// bytes. Initialize every byte, then convert it to [`Buf`] with
+/// [`write_from_slice`](Self::write_from_slice) or [`assume_init`](Self::assume_init).
+pub struct BufUninit<'a> {
     buffer: Option<Vec<u8>>,
     pool: &'a ZeroPool,
     class_idx: u8,
@@ -112,6 +126,83 @@ impl<'a> Buf<'a> {
     }
 }
 
+impl BufUninit<'_> {
+    #[inline(always)]
+    fn vec(&self) -> &Vec<u8> {
+        // SAFETY: buffer is always Some during public lifetime.
+        unsafe { self.buffer.as_ref().unwrap_unchecked() }
+    }
+
+    #[inline(always)]
+    fn vec_mut(&mut self) -> &mut Vec<u8> {
+        // SAFETY: buffer is always Some during public lifetime.
+        unsafe { self.buffer.as_mut().unwrap_unchecked() }
+    }
+}
+
+impl<'a> BufUninit<'a> {
+    pub(crate) fn new(buffer: Vec<u8>, pool: &'a ZeroPool, class_idx: u8) -> Self {
+        Self { buffer: Some(buffer), pool, class_idx }
+    }
+
+    /// Returns the number of bytes that must be initialized before conversion.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.vec().len()
+    }
+
+    /// Returns the capacity of the underlying allocation.
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.vec().capacity()
+    }
+
+    /// Returns `true` if this buffer has a length of 0.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.vec().is_empty()
+    }
+
+    /// Returns the buffer contents as maybe-uninitialized bytes.
+    #[inline]
+    pub fn as_uninit_mut(&mut self) -> &mut [MaybeUninit<u8>] {
+        let len = self.len();
+        // SAFETY: `MaybeUninit<u8>` may hold any byte state. The returned slice
+        // covers exactly the visible range tracked by this `BufUninit`.
+        unsafe { std::slice::from_raw_parts_mut(self.vec_mut().as_mut_ptr().cast(), len) }
+    }
+
+    /// Initialize the whole buffer from a same-length byte slice.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data.len() != self.len()`.
+    #[must_use]
+    pub fn write_from_slice(mut self, data: &[u8]) -> Buf<'a> {
+        assert_eq!(data.len(), self.len(), "source slice length must match buffer length");
+        if !data.is_empty() {
+            // SAFETY: source and destination are valid for `data.len()` bytes.
+            // `self` owns the destination allocation, so it cannot overlap `data`.
+            unsafe {
+                ptr::copy_nonoverlapping(data.as_ptr(), self.vec_mut().as_mut_ptr(), data.len());
+            };
+        }
+        // SAFETY: every byte in the visible range was just initialized.
+        unsafe { self.assume_init() }
+    }
+
+    /// Convert to [`Buf`] after the caller has initialized every byte.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure all bytes in `0..self.len()` have been initialized.
+    #[must_use]
+    pub unsafe fn assume_init(mut self) -> Buf<'a> {
+        let buffer = self.buffer.take().expect("BufUninit already consumed");
+        Buf::new(buffer, self.pool, self.class_idx)
+    }
+}
+
 // ── Deref to [u8], not Vec<u8> ─────────────────────────────────────────
 
 impl Deref for Buf<'_> {
@@ -139,9 +230,27 @@ impl Drop for Buf<'_> {
     }
 }
 
+impl Drop for BufUninit<'_> {
+    #[inline(always)]
+    fn drop(&mut self) {
+        if let Some(buffer) = self.buffer.take() {
+            self.pool.dealloc(buffer, self.class_idx);
+        }
+    }
+}
+
 impl fmt::Debug for Buf<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Buf")
+            .field("len", &self.len())
+            .field("capacity", &self.capacity())
+            .finish()
+    }
+}
+
+impl fmt::Debug for BufUninit<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BufUninit")
             .field("len", &self.len())
             .field("capacity", &self.capacity())
             .finish()
@@ -297,5 +406,27 @@ mod tests {
         let mut buf = pool.alloc(0);
         buf.write_all(b"hello").unwrap();
         assert_eq!(&*buf, b"hello");
+    }
+
+    #[test]
+    fn test_uninit_write_from_slice() {
+        let pool = ZeroPool::new();
+        let buf = pool.alloc_uninit(5).write_from_slice(b"hello");
+
+        assert_eq!(&*buf, b"hello");
+    }
+
+    #[test]
+    fn test_uninit_as_uninit_mut() {
+        let pool = ZeroPool::new();
+        let mut buf = pool.alloc_uninit(3);
+        let uninit = buf.as_uninit_mut();
+        uninit[0].write(b'a');
+        uninit[1].write(b'b');
+        uninit[2].write(b'c');
+
+        // SAFETY: all three bytes were initialized above.
+        let buf = unsafe { buf.assume_init() };
+        assert_eq!(&*buf, b"abc");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! `ZeroPool` is a high-performance, thread-safe byte allocator that recycles
 //! buffers through size-class bucketing and thread-local caching.
+//! Safe allocations are zero-initialized; use [`ZeroPool::alloc_uninit`] for
+//! full-overwrite workloads that need the fastest path.
 //!
 //! - **Size-class bucketing**: Power-of-two classes (4KB→64MB) for O(1) class selection
 //! - **Lock-free shared pool**: `crossbeam::ArrayQueue` per class — no mutexes
@@ -19,6 +21,16 @@
 //! let mut buf = pool.alloc(1024 * 1024); // 1MB — returned as RAII guard
 //! buf[0] = 42;                            // Deref<Target = [u8]>
 //! // automatically deallocated back to pool on drop
+//! ```
+//!
+//! For full-overwrite workloads, skip zeroing with [`ZeroPool::alloc_uninit`]:
+//!
+//! ```rust
+//! use zeropool::ZeroPool;
+//!
+//! let pool = ZeroPool::new();
+//! let buf = pool.alloc_uninit(5).write_from_slice(b"hello");
+//! assert_eq!(&*buf, b"hello");
 //! ```
 //!
 //! # Custom Configuration
@@ -41,10 +53,7 @@
 //! struct PrefaultAllocator;
 //! impl Allocator for PrefaultAllocator {
 //!     fn allocate(&self, capacity: usize) -> Vec<u8> {
-//!         let mut buf = Vec::with_capacity(capacity);
-//!         buf.resize(capacity, 0); // pre-fault pages
-//!         buf.clear();
-//!         buf
+//!         vec![0; capacity]
 //!     }
 //! }
 //!
@@ -80,7 +89,7 @@ mod stats;
 mod tls;
 
 pub use allocator::{Allocator, HeapAllocator};
-pub use buf::Buf;
+pub use buf::{Buf, BufUninit};
 pub use pool::ZeroPool;
 pub use stats::{ClassInfo, Stats};
 
@@ -277,6 +286,27 @@ mod tests {
     }
 
     #[test]
+    fn test_alloc_returns_zeroed_bytes() {
+        let pool = ZeroPool::new().min_buffer_size(0);
+
+        let buf = pool.alloc(4096);
+        assert!(buf.iter().all(|&byte| byte == 0));
+    }
+
+    #[test]
+    fn test_reused_buffer_does_not_expose_previous_contents() {
+        let pool = ZeroPool::new().min_buffer_size(0).tls_cache_size(2);
+
+        {
+            let mut buf = pool.alloc(4096);
+            buf.fill(0xA5);
+        }
+
+        let buf = pool.alloc(4096);
+        assert!(buf.iter().all(|&byte| byte == 0));
+    }
+
+    #[test]
     fn test_size_class_routing() {
         use std::thread;
 
@@ -446,7 +476,7 @@ mod tests {
         struct DoubleCapAllocator;
         impl Allocator for DoubleCapAllocator {
             fn allocate(&self, capacity: usize) -> Vec<u8> {
-                Vec::with_capacity(capacity * 2)
+                vec![0; capacity * 2]
             }
         }
 

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -110,7 +110,7 @@ impl ZeroPool {
     /// struct MyAllocator;
     /// impl Allocator for MyAllocator {
     ///     fn allocate(&self, capacity: usize) -> Vec<u8> {
-    ///         Vec::with_capacity(capacity)
+    ///         vec![0; capacity]
     ///     }
     /// }
     ///
@@ -181,7 +181,7 @@ impl ZeroPool {
         self
     }
 
-    /// Allocate a buffer of at least `size` bytes.
+    /// Allocate a zero-initialized buffer of at least `size` bytes.
     ///
     /// Returns a [`Buf`](crate::Buf) that automatically deallocates back
     /// to the pool on drop.
@@ -212,7 +212,8 @@ impl ZeroPool {
                 self.state.counters.oversize.fetch_add(1, Ordering::Relaxed);
                 self.state.counters.allocations.fetch_add(1, Ordering::Relaxed);
             }
-            let mut buf = self.allocate_raw(size, size);
+            let mut buf = self.state.allocator.allocate(size);
+            buf.truncate(size);
             self.pin(&mut buf);
             return crate::Buf::new(buf, self, u8::MAX);
         };
@@ -240,7 +241,7 @@ impl ZeroPool {
             } else if self.state.track_stats {
                 self.state.counters.shared_hits.fetch_add(1, Ordering::Relaxed);
             }
-            SizeClass::resize(&mut buf, size);
+            SizeClass::resize_zeroed(&mut buf, size);
             return crate::Buf::new(buf, self, ci);
         }
 
@@ -248,9 +249,68 @@ impl ZeroPool {
         if self.state.track_stats {
             self.state.counters.allocations.fetch_add(1, Ordering::Relaxed);
         }
-        let mut buf = self.allocate_raw(class.class_size, size);
+        let mut buf = self.state.allocator.allocate(class.class_size);
+        buf.truncate(size);
         self.pin(&mut buf);
         crate::Buf::new(buf, self, ci)
+    }
+
+    /// Allocate a buffer without zeroing its contents.
+    ///
+    /// This is the high-performance allocation path for workloads that fully
+    /// overwrite the buffer before reading it. The returned [`BufUninit`](crate::BufUninit)
+    /// does not expose a readable byte slice in safe code.
+    #[inline]
+    #[must_use]
+    pub fn alloc_uninit(&self, size: usize) -> crate::BufUninit<'_> {
+        if self.state.track_stats {
+            self.state.counters.gets.fetch_add(1, Ordering::Relaxed);
+        }
+
+        let Some((class_idx, class)) = self.state.table.route(size) else {
+            if self.state.track_stats {
+                self.state.counters.oversize.fetch_add(1, Ordering::Relaxed);
+                self.state.counters.allocations.fetch_add(1, Ordering::Relaxed);
+            }
+            let mut buf = Vec::with_capacity(size);
+            SizeClass::resize_uninit(&mut buf, size);
+            self.pin(&mut buf);
+            return crate::BufUninit::new(buf, self, u8::MAX);
+        };
+
+        let tls_result = TlsState::with(|tls| {
+            if !tls.owns(self.state.id) {
+                tls.bind(self.state.id, self.state.tls_cache_size);
+            }
+
+            if let Some(buf) = tls.caches[class_idx].pop() {
+                return Some((buf, true));
+            }
+
+            tls.refill(class_idx, class, self.state.batch_size).map(|buf| (buf, false))
+        });
+
+        let ci = class_idx as u8;
+
+        if let Some((mut buf, from_tls)) = tls_result {
+            if from_tls {
+                if self.state.track_stats {
+                    self.state.counters.tls_hits.fetch_add(1, Ordering::Relaxed);
+                }
+            } else if self.state.track_stats {
+                self.state.counters.shared_hits.fetch_add(1, Ordering::Relaxed);
+            }
+            SizeClass::resize_uninit(&mut buf, size);
+            return crate::BufUninit::new(buf, self, ci);
+        }
+
+        if self.state.track_stats {
+            self.state.counters.allocations.fetch_add(1, Ordering::Relaxed);
+        }
+        let mut buf = Vec::with_capacity(class.class_size);
+        SizeClass::resize_uninit(&mut buf, size);
+        self.pin(&mut buf);
+        crate::BufUninit::new(buf, self, ci)
     }
 
     /// Return a buffer to the pool for reuse.
@@ -389,18 +449,6 @@ impl ZeroPool {
         self.state.counters.reset();
     }
 
-    /// Allocate a raw buffer via the configured allocator and set its length.
-    #[cold]
-    fn allocate_raw(&self, capacity: usize, len: usize) -> Vec<u8> {
-        let mut buf = self.state.allocator.allocate(capacity);
-        // SAFETY: allocator guarantees capacity >= `capacity` >= `len`.
-        // All u8 bit patterns are valid.
-        unsafe {
-            buf.set_len(len);
-        }
-        buf
-    }
-
     /// Pin buffer memory to RAM if configured.
     #[inline(always)]
     fn pin(&self, buffer: &mut Vec<u8>) {
@@ -410,10 +458,7 @@ impl ZeroPool {
         if buffer.capacity() == 0 {
             return;
         }
-        // SAFETY: capacity was allocated; all u8 patterns valid.
-        unsafe { buffer.set_len(buffer.capacity()) };
-        let _ = region::lock(buffer.as_ptr(), buffer.len());
-        buffer.clear();
+        let _ = region::lock(buffer.as_ptr(), buffer.capacity());
     }
 }
 

--- a/src/size_class.rs
+++ b/src/size_class.rs
@@ -158,16 +158,28 @@ impl SizeClass {
         }
     }
 
-    /// Resize a recycled buffer to the requested length.
+    /// Resize a recycled buffer to the requested length and zero exposed bytes.
     #[inline(always)]
-    pub fn resize(buf: &mut Vec<u8>, requested_len: usize) {
+    pub fn resize_zeroed(buf: &mut Vec<u8>, requested_len: usize) {
         debug_assert!(
             requested_len <= buf.capacity(),
             "requested_len ({requested_len}) > capacity ({})",
             buf.capacity(),
         );
-        // SAFETY: requested_len ≤ capacity (asserted above in debug,
-        // guaranteed by class routing in release). All u8 patterns valid.
+        buf.resize(requested_len, 0);
+    }
+
+    /// Resize a recycled buffer without initializing newly exposed bytes.
+    #[inline(always)]
+    pub fn resize_uninit(buf: &mut Vec<u8>, requested_len: usize) {
+        debug_assert!(
+            requested_len <= buf.capacity(),
+            "requested_len ({requested_len}) > capacity ({})",
+            buf.capacity(),
+        );
+        // SAFETY: requested_len <= capacity (asserted above in debug,
+        // guaranteed by class routing in release). `BufUninit` prevents safe
+        // reads until callers initialize the visible range.
         unsafe { buf.set_len(requested_len) };
     }
 


### PR DESCRIPTION
## Summary
- make safe alloc() return zero-initialized readable buffers
- add alloc_uninit() and BufUninit for full-overwrite fast paths
- update allocator contract, docs, benchmarks, and unsafe lint policy

## Validation
- cargo fmt --check
- cargo test
- cargo clippy --all-targets --all-features
- git diff --check
- targeted Criterion benchmarks for safe alloc() and alloc_uninit()