### PR TITLE
Expand allocator benchmark comparisons

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -16,7 +16,7 @@ your `lscpu`, `rustc --version`, and the exact `cargo bench` command.
 | OS | Linux |
 | Rust | stable |
 | Criterion | 0.7 |
-| Build | `cargo bench --features bench` (release) |
+| Build | `cargo bench --bench pool --features bench` (release) |
 
 ## Methodology
 
@@ -26,10 +26,22 @@ your `lscpu`, `rustc --version`, and the exact `cargo bench` command.
 - All **hot_path** benchmarks are pure allocation / drop with no page writes.
   `alloc()` measures the safe zero-initialized path; `alloc_uninit()` measures
   the explicit full-overwrite fast path.
+- **full_overwrite** initializes every byte after allocation. This is the fair
+  workload for explicit capacity/uninitialized APIs because callers never read
+  stale bytes.
+- `vec_reuse_*` cases measure application-level `Vec` retention separately from
+  allocator-local caching. They answer whether a caller can get close to pooling
+  by keeping a reusable vector per worker.
 - Each Criterion group runs at least 30 samples (50+ for write workloads)
   with default warm-up.
 - Comparison crates are pulled in only with `--features bench` so the
   default `cargo add zeropool` does not download them.
+- Global allocators are selected by Cargo feature for the `pool` bench. Rust
+  allows one process-wide `#[global_allocator]`, so `mimalloc`, `tcmalloc`,
+  `jemalloc`, and the system allocator must be measured in separate runs. Enable
+  only one `bench-alloc-*` feature for a real measurement. The tcmalloc backend
+  uses `tcmalloc-better` and is Linux-only; on other targets that feature leaves
+  the system allocator in place.
 
 ## Headline result
 
@@ -144,19 +156,25 @@ production hot paths.
 
 ```bash
 # Full suite, comparison crates included
-cargo bench --features bench
+cargo bench --bench pool --features bench
+
+# Same suite under alternative process-wide global allocators
+cargo bench --bench pool --features bench,bench-alloc-mimalloc
+cargo bench --bench pool --features bench,bench-alloc-tcmalloc
+cargo bench --bench pool --features bench,bench-alloc-jemalloc
 
 # Single groups
-cargo bench -- hot_path
-cargo bench -- realistic
-cargo bench -- scale
-cargo bench -- mixed
-cargo bench -- burst
-cargo bench -- contention
-cargo bench -- stats
+cargo bench --bench pool -- hot_path
+cargo bench --bench pool -- realistic
+cargo bench --bench pool -- full_overwrite
+cargo bench --bench pool -- scale
+cargo bench --bench pool -- mixed
+cargo bench --bench pool -- burst
+cargo bench --bench pool -- contention
+cargo bench --bench pool -- stats
 
 # Increase the sustained workload from 10k → 100k ops/thread
-ZEROPOOL_SCALE_OPS=100000 cargo bench --features bench -- scale
+ZEROPOOL_SCALE_OPS=100000 cargo bench --bench pool --features bench -- scale
 ```
 
 Criterion writes machine-readable `estimates.json` files under

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anes"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +57,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -60,10 +75,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.2.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "ciborium"
@@ -116,6 +156,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "criterion"
@@ -191,10 +237,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "futures-core"
@@ -221,6 +282,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,6 +302,36 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "zerocopy",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -245,6 +348,16 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -270,6 +383,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libtcmalloc-sys"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e204268a3b09862788a2894346c768b95b2cb29cba42c5e2bb9ea7f48fa317"
+dependencies = [
+ "cc",
+ "document-features",
+ "libc",
+ "patch",
+ "strum",
+]
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +418,12 @@ checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "mach2"
@@ -292,6 +439,42 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom_locate"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e3c83c053b0713da60c5b8de47fe8e494fe3ece5267b2f23090a07a053ba8f3"
+dependencies = [
+ "bytecount",
+ "memchr",
+ "nom",
+]
 
 [[package]]
 name = "num-traits"
@@ -356,6 +539,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "patch"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c07fdcdd8b05bdcf2a25bc195b6c34cbd52762ada9dba88bf81e7686d14e7a"
+dependencies = [
+ "chrono",
+ "nom",
+ "nom_locate",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +600,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rayon"
@@ -551,6 +751,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +769,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,6 +798,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tcmalloc-better"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18b5ddc00f3d012cfe4227eb44c05f7b57b97e494968ea0d2ba114b5b7b3909a"
+dependencies = [
+ "document-features",
+ "libtcmalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -597,6 +854,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -664,10 +930,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"
@@ -752,6 +1071,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "zerocopy"
 version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -778,10 +1103,13 @@ dependencies = [
  "bytes",
  "criterion",
  "crossbeam-queue",
+ "mimalloc",
  "object-pool",
  "opool",
  "region",
  "sharded-slab",
+ "tcmalloc-better",
+ "tikv-jemallocator",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,11 @@ sharded-slab = { version = "0.1", optional = true }
 bytes = { version = "1.5", optional = true }
 object-pool = { version = "0.6", optional = true }
 opool = { version = "0.2.0", optional = true }
+mimalloc = { version = "0.1.52", optional = true }
+tikv-jemallocator = { version = "0.7.0", optional = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+tcmalloc-better = { version = "0.1.19", optional = true }
 
 [dev-dependencies]
 criterion = "0.7"
@@ -98,6 +103,9 @@ criterion = "0.7"
 [features]
 default = []
 bench = ["dep:sharded-slab", "dep:bytes", "dep:object-pool", "dep:opool"]
+bench-alloc-mimalloc = ["dep:mimalloc"]
+bench-alloc-tcmalloc = ["dep:tcmalloc-better"]
+bench-alloc-jemalloc = ["dep:tikv-jemallocator"]
 
 [[bench]]
 name = "pool"

--- a/benches/common/touch.rs
+++ b/benches/common/touch.rs
@@ -2,6 +2,7 @@
 //! of the buffer to model real workloads (networking, file I/O, etc).
 
 use std::hint::black_box;
+use std::mem::MaybeUninit;
 
 /// Write one byte per 4 KiB page to force page faults on a fresh buffer.
 #[inline]
@@ -11,6 +12,23 @@ pub fn touch_pages(buf: &mut [u8]) {
     while i < buf.len() {
         buf[i] = 0xAB;
         i += step;
+    }
+    black_box(buf);
+}
+
+/// Write every byte. This models full-overwrite call sites that can safely use
+/// `alloc_uninit()` or `Vec::with_capacity()` before initialization.
+#[inline]
+pub fn write_all(buf: &mut [u8]) {
+    buf.fill(0xAB);
+    black_box(buf);
+}
+
+/// Initialize every byte in an uninitialized buffer.
+#[inline]
+pub fn write_all_uninit(buf: &mut [MaybeUninit<u8>]) {
+    for byte in &mut *buf {
+        byte.write(0xAB);
     }
     black_box(buf);
 }

--- a/benches/pool.rs
+++ b/benches/pool.rs
@@ -1,24 +1,48 @@
-//! Criterion benchmark suite for ZeroPool.
-//!
-//! Run a subset:
-//!
-//! ```text
-//! cargo bench -- hot_path
-//! cargo bench -- realistic
-//! cargo bench -- scale
-//! cargo bench -- mixed
-//! cargo bench -- burst
-//! cargo bench -- contention
-//! cargo bench -- stats
-//! ```
-//!
-//! Run with full comparison crates (opool, object_pool, sharded_slab, bytes):
-//!
-//! ```text
-//! cargo bench --features bench
-//! ```
-
 #![allow(missing_docs)]
+
+// Criterion benchmark suite for ZeroPool.
+//
+// Run a subset:
+//
+// ```text
+// cargo bench -- hot_path
+// cargo bench -- realistic
+// cargo bench -- full_overwrite
+// cargo bench -- scale
+// cargo bench -- mixed
+// cargo bench -- burst
+// cargo bench -- contention
+// cargo bench -- stats
+// ```
+//
+// Run with full comparison crates (opool, object_pool, sharded_slab, bytes):
+//
+// ```text
+// cargo bench --bench pool --features bench
+// cargo bench --bench pool --features bench,bench-alloc-mimalloc
+// cargo bench --bench pool --features bench,bench-alloc-tcmalloc
+// cargo bench --bench pool --features bench,bench-alloc-jemalloc
+// ```
+
+#[cfg(feature = "bench-alloc-mimalloc")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(all(
+    not(feature = "bench-alloc-mimalloc"),
+    target_os = "linux",
+    feature = "bench-alloc-tcmalloc"
+))]
+#[global_allocator]
+static GLOBAL: tcmalloc_better::TCMalloc = tcmalloc_better::TCMalloc;
+
+#[cfg(all(
+    not(feature = "bench-alloc-mimalloc"),
+    any(not(feature = "bench-alloc-tcmalloc"), not(target_os = "linux")),
+    feature = "bench-alloc-jemalloc"
+))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 mod common;
 
@@ -31,7 +55,7 @@ use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_m
 use common::sizes::{
     BURST_SIZES, MIXED_SIZES, SCALE_THREAD_COUNTS, SIZES, THREAD_COUNTS, ZIPF_SIZES,
 };
-use common::touch::touch_pages;
+use common::touch::{touch_pages, write_all, write_all_uninit};
 
 use zeropool::ZeroPool;
 
@@ -75,6 +99,23 @@ fn hot_path(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::new("vec_capacity", size), &size, |b, &size| {
             b.iter(|| {
                 let buf = Vec::<u8>::with_capacity(size);
+                black_box(&buf);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("vec_reuse_capacity", size), &size, |b, &size| {
+            let mut buf = Vec::<u8>::with_capacity(size);
+            b.iter(|| {
+                buf.clear();
+                black_box(&buf);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("vec_reuse_zeroed", size), &size, |b, &size| {
+            let mut buf = vec![0u8; size];
+            b.iter(|| {
+                buf.clear();
+                buf.resize(size, 0);
                 black_box(&buf);
             });
         });
@@ -133,6 +174,15 @@ fn realistic(c: &mut Criterion) {
             group.bench_with_input(BenchmarkId::new("vec_alloc", size), &size, |b, &size| {
                 b.iter(|| {
                     let mut buf = vec![0u8; size];
+                    touch_pages(&mut buf);
+                });
+            });
+
+            group.bench_with_input(BenchmarkId::new("vec_reuse", size), &size, |b, &size| {
+                let mut buf = vec![0u8; size];
+                b.iter(|| {
+                    buf.clear();
+                    buf.resize(size, 0);
                     touch_pages(&mut buf);
                 });
             });
@@ -210,6 +260,27 @@ fn realistic(c: &mut Criterion) {
                 },
             );
 
+            group.bench_with_input(
+                BenchmarkId::new("vec_thread_local_reuse", threads),
+                &threads,
+                |b, &threads| {
+                    b.iter(|| {
+                        thread::scope(|s| {
+                            for _ in 0..threads {
+                                s.spawn(|| {
+                                    let mut buf = vec![0u8; size];
+                                    for _ in 0..ops {
+                                        buf.clear();
+                                        buf.resize(size, 0);
+                                        touch_pages(&mut buf);
+                                    }
+                                });
+                            }
+                        });
+                    });
+                },
+            );
+
             #[cfg(feature = "bench")]
             {
                 group.bench_with_input(
@@ -258,6 +329,88 @@ fn realistic(c: &mut Criterion) {
 
         group.finish();
     }
+}
+
+// ── full_overwrite ─────────────────────────────────────────────────────
+//
+// Alloc + initialize every byte + drop. This is the fair workload for
+// explicit uninitialized/capacity APIs because callers never read old bytes.
+
+fn full_overwrite(c: &mut Criterion) {
+    let mut group = c.benchmark_group("full_overwrite");
+
+    for &size in SIZES {
+        group.throughput(Throughput::Bytes(size as u64));
+
+        group.bench_with_input(BenchmarkId::new("zeropool_zeroed", size), &size, |b, &size| {
+            let pool = common::competitors::zeropool_no_min();
+            pool.warm(1, size);
+            b.iter(|| {
+                let mut buf = pool.alloc(size);
+                write_all(&mut buf);
+                drop(buf);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("zeropool_uninit", size), &size, |b, &size| {
+            let pool = common::competitors::zeropool_no_min();
+            pool.warm(1, size);
+            b.iter(|| {
+                let mut buf = pool.alloc_uninit(size);
+                write_all_uninit(buf.as_uninit_mut());
+                // SAFETY: `write_all_uninit` initialized the entire buffer.
+                let buf = unsafe { buf.assume_init() };
+                drop(buf);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("vec_zeroed", size), &size, |b, &size| {
+            b.iter(|| {
+                let mut buf = vec![0u8; size];
+                write_all(&mut buf);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("vec_capacity", size), &size, |b, &size| {
+            b.iter(|| {
+                let mut buf = Vec::<u8>::with_capacity(size);
+                write_all_uninit(&mut buf.spare_capacity_mut()[..size]);
+                // SAFETY: `write_all_uninit` initializes exactly `size` bytes.
+                unsafe { buf.set_len(size) };
+                black_box(&buf);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("vec_reuse_zeroed", size), &size, |b, &size| {
+            let mut buf = vec![0u8; size];
+            b.iter(|| {
+                buf.clear();
+                buf.resize(size, 0);
+                write_all(&mut buf);
+            });
+        });
+
+        #[cfg(feature = "bench")]
+        {
+            group.bench_with_input(BenchmarkId::new("object_pool", size), &size, |b, &size| {
+                let pool = common::competitors::object_pool_zeroed(size, 16);
+                b.iter(|| {
+                    let mut buf = pool.pull(|| vec![0u8; size]);
+                    write_all(&mut buf);
+                });
+            });
+
+            group.bench_with_input(BenchmarkId::new("opool", size), &size, |b, &size| {
+                let pool = common::competitors::opool_capacity(64, size);
+                b.iter(|| {
+                    let mut buf = pool.get();
+                    write_all(&mut buf);
+                });
+            });
+        }
+    }
+
+    group.finish();
 }
 
 // ── scale_sustained ───────────────────────────────────────────────────
@@ -656,6 +809,7 @@ criterion_group!(
     benches,
     hot_path,
     realistic,
+    full_overwrite,
     scale_sustained,
     mixed_sizes,
     burst,


### PR DESCRIPTION
## Summary
- add feature-selected benchmark allocator backends for mimalloc, jemalloc, and Linux tcmalloc
- add Vec reuse/cache and full-overwrite benchmark workloads
- document allocator methodology and benchmark commands

## Validation
- cargo test
- cargo clippy --all-targets --all-features
- cargo check --benches --all-features
- cargo bench --bench pool --features bench --no-run
- cargo bench --bench pool --features bench,bench-alloc-mimalloc --no-run
- cargo bench --bench pool --features bench,bench-alloc-jemalloc --no-run
- cargo bench --bench pool --features bench,bench-alloc-tcmalloc --no-run
- git diff --check